### PR TITLE
Generic marketplace

### DIFF
--- a/market-dapp/backend/contracts/ContentMarketplace.sol
+++ b/market-dapp/backend/contracts/ContentMarketplace.sol
@@ -1,0 +1,151 @@
+pragma solidity ^0.5.1;
+pragma experimental ABIEncoderV2;
+
+contract ContentMarketplace {
+
+    /// @notice records necessary information for an advertisement
+    struct Advertisement {
+        address seller;               // seller address
+        uint256 price;                // trade price
+        bytes32 dataHash;             // merkle hash of unencrypted data
+        bytes32 encryptedDataHash;    // merkle hash of encrypted data
+        bytes ipfsPath;               // ipfs path of encrypted data
+        bytes32 testTemplateHash;     // hash of the machine representing the test procedure for decrypted data
+    }
+
+    /// @notice records information regarding a purchase
+    struct Purchase {
+        uint256 adId;
+        address buyer;
+        bytes buyerKey;
+        bytes encryptedDataKey;
+    }
+
+    // storage of advertisements
+    uint256 numAds = 0;
+    mapping(uint256 => Advertisement) internal ads;
+    mapping(address => uint256[]) internal adsPerSeller;
+
+    // storage of purchases
+    uint256 numPurchases = 0;
+    mapping(uint256 => Purchase) purchases;
+    mapping(uint256 => uint256[]) internal purchasesPerAd;
+
+    // purchase events
+    event PurchaseRequested(uint256 adId, uint256 purchaseId, address buyer, bytes buyerKey);
+    event PurchaseAccepted(uint256 adId, uint256 purchaseId, bytes encryptedDataKey);
+    event PurchaseChallenged(uint256 adId, uint256 purchaseId, uint256 descartesIndex);
+    event PurchaseFinalized(uint256 adId, uint256 purchaseId, bool isSuccess);
+
+
+    /// @param descartesAddress address of the Descartes contract
+    constructor(address descartesAddress) public {
+        // TODO retrieve Descartes interface from the address
+    }
+
+    /// @notice creates a new advertisement for published and encrypted content
+    function createAd(
+        uint256 _price,                // trade price
+        bytes32 _dataHash,             // merkle hash of unencrypted data
+        bytes32 _encryptedDataHash,    // merkle hash of encrypted data
+        bytes memory _ipfsPath,        // ipfs path of encrypted data
+        bytes32 _testTemplateHash      // hash of the machine representing the test procedure for decrypted data
+    ) internal
+        returns (uint256 adId)       // returns ad identifier
+    {
+        Advertisement storage ad = ads[numAds];
+        ad.seller = msg.sender;
+        ad.price = _price;
+        ad.dataHash = _dataHash;
+        ad.encryptedDataHash = _encryptedDataHash;
+        ad.ipfsPath = _ipfsPath;
+        ad.testTemplateHash = _testTemplateHash;
+
+        adId = numAds++;
+        adsPerSeller[ad.seller].push(adId);
+
+        return adId;
+    }
+
+    /// @notice retrieves an advertisement given its identifier
+    function getAd(uint256 _adId) public view
+        returns (Advertisement memory)
+    {
+        return ads[_adId];
+    }
+
+    /// @notice retrieves an array of advertisements given their identifiers
+    function getAds(uint256[] memory _adIds) public view
+        returns (Advertisement[] memory)
+    {
+        Advertisement[] memory ret = new Advertisement[](_adIds.length);
+        for(uint256 i = 0; i < _adIds.length; i++) {
+            uint256 id = _adIds[i];
+            ret[i] = ads[id];
+        }
+        return ret;
+    }
+
+    /// @notice returns identifiers for a seller's advertisements
+    function listAdsPerSeller(address _seller) public view
+        returns (uint256[] memory)
+    {
+        return adsPerSeller[_seller];
+    }
+
+
+    /// @notice requests purchase of a registered advertisement
+    function requestPurchase(
+        uint256 _adId,                 // ad identifier
+        bytes memory _buyerKey         // buyer's public key used for encrypting messages so that only the buyer can see
+    ) public
+        payable                        // funds matching ad price, which will be locked until purchase is finalized
+        returns (uint256 purchaseId)   // returns purchase request identifier
+    {
+        // TODO: ensure ad exists
+        // TODO: ensure funds are adequade
+
+        // stores purchase info
+        Purchase storage purchase = purchases[numPurchases];
+        purchase.adId = _adId;
+        purchase.buyer = msg.sender;
+        purchase.buyerKey = _buyerKey;
+
+        purchaseId = numPurchases++;
+        purchasesPerAd[purchase.adId].push(purchaseId); 
+
+        emit PurchaseRequested(purchase.adId, purchaseId, purchase.buyer, purchase.buyerKey);
+        return purchaseId;
+    }
+
+
+    /// @notice called by seller to accept a purchase request for a registered advertisement
+    function acceptPurchase(
+        uint256 _purchaseId,           // purchase request identifier
+        bytes memory _encryptedDataKey // key for decrypting data, encrypted using buyer's public key
+    ) public
+        payable                        // deposit sent by the seller that will be locked until purchase is finalized
+    {
+        // TODO...
+    }
+
+
+    /// @notice called by buyer to challenge a purchase, stating that content could not be retrieved
+    function challengePurchase(
+        uint256 _purchaseId,           // purchase request identifier
+        bytes memory _privateKey       // buyer's private key used to decrypt the data key
+    ) public
+        returns (uint256 descartesIndex)  // returns index of the descartes computation that will verify the challenge
+    {
+        // TODO...
+    }
+
+
+    /// @notice finalizes purchase, unlocking buyer's funds and seller's deposit as appropriate
+    function finalizePurchase(
+        uint256 _purchaseId            // purchase request identifier
+    ) public {
+        // TODO...
+    }
+
+}

--- a/market-dapp/backend/contracts/STMarketplace.sol
+++ b/market-dapp/backend/contracts/STMarketplace.sol
@@ -12,6 +12,7 @@ contract STMarketplace is ContentMarketplace {
     bytes32 validateCarSetupTemplateHash = "0x123";
     bytes32 validateCarSkinTemplateHash = "0x456";
     
+    // holds information specific to a car setup file
     struct carSetupInfo {
         string carBrand;
         string track;
@@ -19,21 +20,24 @@ contract STMarketplace is ContentMarketplace {
         string season;
     }
        
+    // holds information specific to a car skin file
     struct carSkinInfo {
         string carBrand;
         string simulator;
     }
        
+    // full representation of an advertised car setup
     struct carSetup {
-        uint256 id;
-        Advertisement ad;
-        carSetupInfo info;
+        uint256 id;         // id of the advertisement
+        Advertisement ad;   // generic ad information, including seller and content
+        carSetupInfo info;  // specific car setup information
     }
        
+    // full representation of an advertised car skin
     struct carSkin {
-        uint256 id;
-        Advertisement ad;
-        carSkinInfo info;
+        uint256 id;         // id of the advertisement
+        Advertisement ad;   // generic ad information, including seller and content
+        carSkinInfo info;   // specific car skin information
     }
 
 

--- a/market-dapp/backend/contracts/STMarketplace.sol
+++ b/market-dapp/backend/contracts/STMarketplace.sol
@@ -1,109 +1,125 @@
 pragma solidity ^0.5.1;
 pragma experimental ABIEncoderV2;
 
+import "./ContentMarketplace.sol";
+
 /// @title Simthunder Sim Racing Marketplace - first iteration
 /// @notice Non-Cartesi blockchain code for registering sellers and sim racing assets
 
-contract STMarketplace {    
+contract STMarketplace is ContentMarketplace {    
+
+    // cartesi machine template used to validate each asset category
+    bytes32 validateCarSetupTemplateHash = "0x123";
+    bytes32 validateCarSkinTemplateHash = "0x456";
     
-    struct carSetup {
-        uint256 itemId;
-        string ipfsHash;
+    struct carSetupInfo {
         string carBrand;
         string track;
         string simulator;
         string season;
-        uint256 price;
-        string _address;
     }
-    
-    struct skin {
-        uint256 itemId;
-        string ipfsHash;
+       
+    struct carSkinInfo {
         string carBrand;
         string simulator;
-        uint256 price;
-        string _address;
+    }
+       
+    struct carSetup {
+        uint256 id;
+        Advertisement ad;
+        carSetupInfo info;
+    }
+       
+    struct carSkin {
+        uint256 id;
+        Advertisement ad;
+        carSkinInfo info;
     }
 
-    struct purchase {
-        uint256 purchaseId;
-        uint256 itemId;
-        address buyer;
-    }
-    
+
     /// @notice Maps the 2 type of files
-    mapping (address => carSetup[]) setupsBySeller;
-    mapping (address => skin[]) skinsBySeller;
+    mapping(uint256 => carSetupInfo) carSetupInfos;
+    mapping(uint256 => carSkinInfo) carSkinInfos;
+    uint256[] carSetupIds;
+    uint256[] carSkinIds;
     
     /// @notice To track if seller address already exists
     mapping (address => bool) userExists;
     
-    /// @notice Keep track of all seller addresses and existing files
+    // /// @notice Keep track of all seller addresses and existing files
     address[] private userAddresses;
-    string[] private ipfsList;
-
-    uint256 public carSetupCounter;
-    uint256 public skinsCounter;
-    uint256 public purchaseCounter;
-    uint256 public itemCounter;
-
-    /// @notice Keep track of all seller sales
-    mapping (address => purchase[]) purchasesBySeller;
 
     /// @notice Events
-    event ipfsSaved(string _ipfsHash, address _address);
-    event carSetupSaved(address _address, string _ipfsHash, string _carBrand, string _track, string _simulator, string _season, uint256 _price);
-    event skinSaved(address _address, string _ipfsHash, string _carBrand, string _simulator, uint256 _price);
-    event newPurchaseRequest(address _address, uint256 itemId);
+    event carSetupSaved(address _address, bytes _ipfsPath, string _carBrand, string _track, string _simulator, string _season, uint256 _price);
+    event skinSaved(address _address, bytes _ipfsPath, string _carBrand, string _simulator, uint256 _price);
     
-    /// @notice An empty constructor that creates an instance of the contract
-    constructor() public{
-        carSetupCounter = 0;
-        skinsCounter = 0;
+    /// @notice Creates an instance of the contract
+    /// @param descartesAddress address of the Descartes contract
+    constructor(address descartesAddress) public ContentMarketplace(descartesAddress) {
     }    
     
     /// @notice Registers a new car setup for sale
-    function newCarSetup(string memory _ipfsHash, string memory _carBrand, string memory _track, string memory _simulator, string memory _season, uint256 _price) public {
-        string memory string_address = addressToString(msg.sender);
-        carSetup memory car = carSetup(itemCounter, _ipfsHash, _carBrand, _track, _simulator, _season, _price, string_address);
-        itemCounter++;
-        setupsBySeller[msg.sender].push(car);
-        carSetupCounter++;
-        ipfsList.push(_ipfsHash);
-        emit carSetupSaved(msg.sender,_ipfsHash, _carBrand, _track, _simulator, _season, _price);
-        if(userExists[msg.sender] == false) {
-            userExists[msg.sender] = true;
-            userAddresses.push(msg.sender);    
-        }
+    function newCarSetup(
+        bytes memory _ipfsPath,        // ipfs path of encrypted data
+        string memory _carBrand,
+        string memory _track,
+        string memory _simulator,
+        string memory _season,
+        uint256 _price,                // trade price
+        bytes32 _dataHash,             // merkle hash of unencrypted data
+        bytes32 _encryptedDataHash     // merkle hash of encrypted data
+    ) public
+        returns (uint256 id)           // returns ad identifier
+    {
+        id = createAd(
+            _price,
+            _dataHash,
+            _encryptedDataHash,
+            _ipfsPath,
+            validateCarSetupTemplateHash
+        );
+
+        carSetupInfo storage info = carSetupInfos[id];
+        info.carBrand = _carBrand;
+        info.track = _track;
+        info.simulator = _simulator;
+        info.season = _season;
+
+        carSetupIds.push(id);
+        saveSeller(msg.sender);
+        emit carSetupSaved(msg.sender, _ipfsPath, _carBrand, _track, _simulator, _season, _price);
+
+        return id;
     }
-    
+
     /// @notice Registers a new car skin for sale
-    function newSkin(string memory _ipfsHash, string memory _carBrand, string memory _simulator, uint256 _price) public {
-        string memory string_address = addressToString(msg.sender);
-        skin memory carSkin = skin(itemCounter, _ipfsHash, _carBrand,  _simulator, _price, string_address);
-        itemCounter++;
-        skinsBySeller[msg.sender].push(carSkin);
-        skinsCounter++;
-        ipfsList.push(_ipfsHash);
-        emit skinSaved (msg.sender,_ipfsHash, _carBrand, _simulator, _price);
-        if(userExists[msg.sender] == false) {
-            userExists[msg.sender] = true;
-            userAddresses.push(msg.sender);    
-        }
-    }
+    function newSkin(
+        bytes memory _ipfsPath,        // ipfs path of encrypted data
+        string memory _carBrand,
+        string memory _simulator,
+        uint256 _price,                // trade price
+        bytes32 _dataHash,             // merkle hash of unencrypted data
+        bytes32 _encryptedDataHash     // merkle hash of encrypted data
+    ) public
+        returns (uint256 id)           // returns ad identifier
+    {
+        id = createAd(
+            _price,
+            _dataHash,
+            _encryptedDataHash,
+            _ipfsPath,
+            validateCarSkinTemplateHash
+        );
 
-    /// @notice Registers a new purchase request
-    function purchaseRequest(uint256 itemId) public returns(uint256) {
-        uint256 purchaseId = purchaseCounter;
-        purchaseCounter++;
-        purchase memory newPurchase = purchase(purchaseCounter, itemId, msg.sender);
-        
-        purchasesBySeller[msg.sender].push(newPurchase);
+        carSkinInfo storage info = carSkinInfos[id];
+        info.carBrand = _carBrand;
+        info.simulator = _simulator;
 
-        emit newPurchaseRequest(msg.sender,itemId);
+        carSkinIds.push(id);
+        saveSeller(msg.sender);
+        emit skinSaved (msg.sender,_ipfsPath, _carBrand, _simulator, _price);
 
-        return purchaseId;
+        return id;
     }
 
     /// @notice Registers seller address
@@ -117,33 +133,25 @@ contract STMarketplace {
     }
     
     /// @notice Gets the list of all car setup files
-    function getCarSetups() public view returns(carSetup[] memory allCars){
-        carSetup[] memory cars = new carSetup[](carSetupCounter);
-        uint256 i = 0;
-        for(uint256 j = 0; j < userAddresses.length; j++) {
-            address _address =  userAddresses[j];
-            
-            for(uint256 k = 0; k < setupsBySeller[_address].length; k++) {
-                carSetup storage car = setupsBySeller[_address][k];
-                cars[i] = car;
-                i++;
-            }
+    function getCarSetups() public view returns(carSetup[] memory setups){
+        setups = new carSetup[](carSetupIds.length);
+        for (uint256 i = 0; i < carSetupIds.length; i++) {
+            uint256 id = carSetupIds[i];
+            setups[i].id = id;
+            setups[i].ad = ads[id];
+            setups[i].info = carSetupInfos[id];
         }
-        return cars;
+        return setups;
     }
     
     /// @notice Gets the list of all skin files
-    function getSkins() public view returns(skin[] memory allSkins){
-        skin[] memory skins = new skin[](skinsCounter);
-        uint256 i = 0;
-        for(uint256 j = 0; j < userAddresses.length; j++) {
-            address _address =  userAddresses[j];
-            
-            for(uint256 k = 0; k < skinsBySeller[_address].length; k++) {
-                skin storage skin2 = skinsBySeller[_address][k];
-                skins[i] = skin2;
-                i++;
-            }
+    function getSkins() public view returns(carSkin[] memory skins){
+        skins = new carSkin[](carSkinIds.length);
+        for(uint256 i = 0; i < carSkinIds.length; i++) {
+            uint256 id = carSkinIds[i];
+            skins[i].id = id;
+            skins[i].ad = ads[id];
+            skins[i].info = carSkinInfos[id];
         }
         return skins;
     }
@@ -160,12 +168,12 @@ contract STMarketplace {
     
     /// @notice Gets number of car setup files
     function getNumberCars() public view returns(uint256) {
-        return carSetupCounter;
+        return carSetupIds.length;
     }
     
     /// @notice Gets number of skin files
     function getNumberSkins() public view returns(uint256) {
-        return skinsCounter;
+        return carSkinIds.length;
     }
     
     /// @notice Utility method to return string from an address

--- a/market-dapp/backend/migrations/2_deploy_ipfscontract.js
+++ b/market-dapp/backend/migrations/2_deploy_ipfscontract.js
@@ -1,5 +1,7 @@
 var STMarketplace = artifacts.require("./STMarketplace.sol");
 
 module.exports = function(deployer) {
-  deployer.deploy(STMarketplace, '0x5660a2Ead35A975D9F7C96d0B5f5FA12A12710d8');
+  //TODO: change placeholder address for the real deployed Descartes address
+  const placeholder = '0x5660a2Ead35A975D9F7C96d0B5f5FA12A12710d8';
+  deployer.deploy(STMarketplace, placeholder);
 };

--- a/market-dapp/backend/migrations/2_deploy_ipfscontract.js
+++ b/market-dapp/backend/migrations/2_deploy_ipfscontract.js
@@ -1,5 +1,5 @@
 var STMarketplace = artifacts.require("./STMarketplace.sol");
 
 module.exports = function(deployer) {
-  deployer.deploy(STMarketplace);
+  deployer.deploy(STMarketplace, '0x5660a2Ead35A975D9F7C96d0B5f5FA12A12710d8');
 };

--- a/market-dapp/client/src/pages/UploadCar.js
+++ b/market-dapp/client/src/pages/UploadCar.js
@@ -122,8 +122,14 @@ class UploadCar extends Component {
             console.log("Current season: " + this.state.currentSeason);
             console.log("Current price: " + this.state.currentFilePrice);
 
-            const response = await this.state.contract.methods.newCarSetup(this.state.ipfsHash, this.state.currentCar, this.state.currentTrack,
-                this.state.currentSimulator, this.state.currentSeason, price).send({ from: this.state.currentAccount });
+            const ipfsHashBytes = this.state.drizzle.web3.utils.fromAscii(this.state.ipfsHash);
+            
+            // TO DO: change placeholders for correct values
+            const placeholder = this.state.drizzle.web3.utils.fromAscii('some hash');
+            console.log(placeholder);
+
+            const response = await this.state.contract.methods.newCarSetup(ipfsHashBytes, this.state.currentCar, this.state.currentTrack,
+                this.state.currentSimulator, this.state.currentSeason, price, placeholder, placeholder).send({ from: this.state.currentAccount });
             console.log(response);
 
             alert("The new car setup is available for sale!");

--- a/market-dapp/client/src/pages/UploadSkin.js
+++ b/market-dapp/client/src/pages/UploadSkin.js
@@ -108,8 +108,14 @@ class UploadSkin extends Component {
             console.log("Current simulator: " + this.state.currentSimulator);
             console.log("Current price: " + this.state.currentFilePrice);
 
-            const response = await this.state.contract.methods.newSkin(this.state.ipfsHash, this.state.currentCar,
-                this.state.currentSimulator, price).send({ from: this.state.currentAccount });
+            const ipfsHashBytes = this.state.drizzle.web3.utils.fromAscii(this.state.ipfsHash);
+            
+            // TO DO: change placeholders for correct values
+            const placeholder = this.state.drizzle.web3.utils.fromAscii('some hash');
+            console.log(placeholder);
+
+            const response = await this.state.contract.methods.newSkin(ipfsHashBytes, this.state.currentCar,
+                this.state.currentSimulator, price, placeholder, placeholder).send({ from: this.state.currentAccount });
             console.log(response);
 
             alert("The new skin is available for sale!");


### PR DESCRIPTION
This is a proposal for separating `STMarketplace` into ST-specific code and a more generic marketplace code. 

The basic idea is that `STMarketplace` will now inherit from a generic `ContentMarketplace` contract, adding methods and structs specific to CarSetups and CarSkins, as well as extra methods used by the front-end client. As such, `ContentMarketplace` will now contain only the code that's strictly required to perform a purchase backed by Descartes (for the challenges etc), thus making it easier to be reused for a number of other applications.

Some additional notes:
- Some fields were added to the generic advertisement structure that were not present before. Namely, `dataHash` (hash of decrypted data, to check if the final result is ok), `encryptedDataHash` (hash of encrypted data, to check that data downloaded from IPFS is ok) and `testTemplateHash` (hash that identifies the Cartesi Machine to be used to validate the content, which may differ per asset - i.e., we may have a different content validator for car setups and skins)
- The `carSetup` and `carSkin` structures returned by the public methods `getCarSetups()` and `getSkins()` are now separating the generic advertisement info from the setup or skin-specific info, for simplicity of implementation. This could be "flattened" out if desired to remain closer to the previous structures.
- We should keep in mind that these public methods `getCarSetups()` and `getSkins()` may be dangerous: what would happen if there were a million car setup files advertised on the platform? 
