### PR TITLE
Backend `test` dir with Descartes instantiation

### DIFF
--- a/market-dapp/backend/test/calculator/build-cartesi-machine.sh
+++ b/market-dapp/backend/test/calculator/build-cartesi-machine.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# general definitions
+MACHINES_DIR=.
+MACHINE_TEMP_DIR=__temp_machine
+CARTESI_PLAYGROUND_DOCKER=cartesi/playground:0.3.0
+
+# set machines directory to specified path if provided
+if [ $1 ]; then
+  MACHINES_DIR=$1
+fi
+
+# removes machine temp store directory if it exists
+if [ -d "$MACHINE_TEMP_DIR" ]; then
+  rm -r $MACHINE_TEMP_DIR
+fi
+
+# builds machine (running with 0 cycles)
+# - initial (template) hash is printed on screen
+# - machine is stored in temporary directory
+docker run \
+  -e USER=$(id -u -n) \
+  -e GROUP=$(id -g -n) \
+  -e UID=$(id -u) \
+  -e GID=$(id -g) \
+  -v `pwd`:/home/$(id -u -n) \
+  -w /home/$(id -u -n) \
+  --rm $CARTESI_PLAYGROUND_DOCKER cartesi-machine \
+    --max-mcycle=0 \
+    --initial-hash \
+    --store="$MACHINE_TEMP_DIR" \
+    --flash-drive="label:input,length:1<<12" \
+    --flash-drive="label:output,length:1<<12" \
+    -- $'dd status=none if=$(flashdrive input) | lua -e \'print((string.unpack("z",  io.read("a"))))\' | bc | dd status=none of=$(flashdrive output)'
+
+# moves stored machine to a folder within $MACHINES_DIR named after the machine's hash
+mv $MACHINE_TEMP_DIR $MACHINES_DIR/$(docker run \
+  -e USER=$(id -u -n) \
+  -e GROUP=$(id -g -n) \
+  -e UID=$(id -u) \
+  -e GID=$(id -g) \
+  -v `pwd`:/home/$(id -u -n) \
+  -h playground \
+  -w /home/$(id -u -n) \
+  --rm $CARTESI_PLAYGROUND_DOCKER cartesi-machine-stored-hash $MACHINE_TEMP_DIR/)

--- a/market-dapp/backend/test/calculator/instantiate.ts
+++ b/market-dapp/backend/test/calculator/instantiate.ts
@@ -8,7 +8,6 @@
  * - "data": defines mathematical expression to evaluate (default is "2^71 + 36^12")
  */
 import hre from "hardhat";
-import DescartesJson from "@cartesi/descartes-sdk/export/artifacts/Descartes.json";
 
 async function main() {
   const { ethers, getNamedAccounts } = hre;
@@ -20,7 +19,7 @@ async function main() {
   let [signer] = await ethers.getSigners();
   const descartes = new ethers.Contract(
     Descartes.address,
-    DescartesJson.abi,
+    Descartes.abi,
     signer
   );
 

--- a/market-dapp/backend/test/calculator/instantiate.ts
+++ b/market-dapp/backend/test/calculator/instantiate.ts
@@ -1,0 +1,79 @@
+/**
+ * Calculator instantiate
+ *
+ * Basic usage
+ * - npx hardhat run --network localhost --no-compile calculator/instantiate.ts
+ *
+ * Parametrization (setting env variables)
+ * - "data": defines mathematical expression to evaluate (default is "2^71 + 36^12")
+ */
+import hre from "hardhat";
+import DescartesJson from "@cartesi/descartes-sdk/export/artifacts/Descartes.json";
+
+async function main() {
+  const { ethers, getNamedAccounts } = hre;
+  const { Descartes } = await hre.deployments.all();
+
+  const { alice, bob } = await getNamedAccounts();
+
+  // retrieves deployed Descartes instance based on its address and ABI
+  let [signer] = await ethers.getSigners();
+  const descartes = new ethers.Contract(
+    Descartes.address,
+    DescartesJson.abi,
+    signer
+  );
+
+  let data = "2^71 + 36^12";
+  if (process.env.data) {
+    data = process.env.data;
+  }
+  console.log("");
+  console.log(`Instantiating "Calculator" for data "${data}"...\n`);
+
+  // defines input drive
+  const input = {
+    position: "0x9000000000000000",
+    driveLog2Size: 5,
+    directValue: ethers.utils.toUtf8Bytes(data),
+    loggerIpfsPath: ethers.utils.formatBytes32String(""),
+    loggerRootHash: ethers.utils.formatBytes32String(""),
+    waitsProvider: false,
+    needsLogger: false,
+    provider: alice,
+  };
+
+  // instantiates descartes computation
+  const tx = await descartes.instantiate(
+    // final time: 1e11 gives us ~50 seconds for completing the computation itself
+    1e11,
+    // template hash
+    "0xa278371ed8d52efa6aba9f825ba8130d2604b363b3ceb51c1bd3a210f400fd8a",
+    // output position
+    "0xa000000000000000",
+    // output log2 size
+    10,
+    // round duration
+    51,
+    [alice, bob],
+    [input]
+  );
+
+  // retrieves created computation's index
+  const index = await new Promise((resolve) => {
+    descartes.on("DescartesCreated", (index) => resolve(index));
+  });
+
+  console.log(
+    `Instantiation successful with index '${index}' (tx: ${tx.hash} ; blocknumber: ${tx.blockNumber})\n`
+  );
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/market-dapp/backend/test/getResult.ts
+++ b/market-dapp/backend/test/getResult.ts
@@ -8,7 +8,6 @@
  * - "index": controls which Descartes computation to query (default is 0)
  */
 import hre from "hardhat";
-import DescartesJson from "@cartesi/descartes-sdk/export/artifacts/Descartes.json";
 
 async function main() {
   const { ethers } = hre;
@@ -18,7 +17,7 @@ async function main() {
   let [signer] = await ethers.getSigners();
   const descartes = new ethers.Contract(
     Descartes.address,
-    DescartesJson.abi,
+    Descartes.abi,
     signer
   );
 

--- a/market-dapp/backend/test/getResult.ts
+++ b/market-dapp/backend/test/getResult.ts
@@ -1,0 +1,49 @@
+/**
+ * getResult: returns the Descartes result for a given index (default index = 0)
+ *
+ * Basic usage
+ * - npx hardhat run --network localhost --no-compile getResult.ts
+ *
+ * Parametrization (setting env variables)
+ * - "index": controls which Descartes computation to query (default is 0)
+ */
+import hre from "hardhat";
+import DescartesJson from "@cartesi/descartes-sdk/export/artifacts/Descartes.json";
+
+async function main() {
+  const { ethers } = hre;
+  const { Descartes } = await hre.deployments.all();
+
+  // retrieves deployed Descartes instance based on its address and ABI
+  let [signer] = await ethers.getSigners();
+  const descartes = new ethers.Contract(
+    Descartes.address,
+    DescartesJson.abi,
+    signer
+  );
+
+  let index = "0";
+  if (process.env.index) {
+    index = process.env.index;
+  }
+  console.log("");
+  console.log("Getting result using index '" + index + "'\n");
+
+  const ret = await descartes.getResult(index);
+  console.log("Full result: " + JSON.stringify(ret));
+  if (ret["3"]) {
+    console.log(
+      `Result value as string: ${ethers.utils.toUtf8String(ret["3"])}`
+    );
+  }
+  console.log("");
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/market-dapp/backend/test/tsconfig.json
+++ b/market-dapp/backend/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "declaration": true,
+        "target": "es5",
+        "module": "commonjs",
+        "strict": true,
+        "resolveJsonModule": true,
+        "esModuleInterop": true,
+        "outDir": "dist"
+    }
+}


### PR DESCRIPTION
- Runs `calculator` example
- Calculator machine should be built and stored in ./backend/machines
- Requires running Descartes env with `docker-compose up` from ./backend